### PR TITLE
Add: Traits parameter to sow_seeds options

### DIFF
--- a/lib/seed_packet.rb
+++ b/lib/seed_packet.rb
@@ -32,12 +32,14 @@ module SeedPacket
     if environment.seeding_allowed?
       display_items       = options.fetch(:display_items, false)
       count               = options.fetch(:count,         rand(20))
+      traits              = options.fetch(:traits,        [])
       overridden_values   = options.fetch(:values,        {})
       additional_message  = options.fetch(:message,       '')
 
       sample_factory_name = "#{factory}_sample"
       sample_items        = factory_class.create_list(sample_factory_name,
                                                       count,
+                                                      *traits,
                                                       overridden_values)
 
       if display_items


### PR DESCRIPTION
Allow FactoryBot traits to be passed into sow_seeds. The traits are passed as
an array.

<!--- Well formatted issues help everyone.  Take a few minutes to get a -->
<!--- primer on markdown here: http://bit.ly/2lB1raW -->

## Why This Change Is Necessary
Allow traits to be passed into sow_seeds for factory creation
<!--- Identify the High Level Type of Change -->
- [ ] Bug Fix
- [x] New Feature

<!--- Now describe to reviewers of your pull request what to expect in the -->
<!--- PR, thereby allowing them to more easily identify and point out -->
<!--- unrelated changes. -->
Adding and using the traits parameter
## How These Changes Address the Issue
<!--- Describe, at a high level, what was done to affect change. -->
<!--- If your change is obvious, you may be able to omit addressing this. -->

## Side Effects Caused By This Change
None
- [ ] This Causes a Breaking Change

<!--- This is the most important topic to answer, as it can point out -->
<!--- problems where you are making too many changes in one commit or branch. -->
<!--- One or two bullet points for related changes may be okay, but five or -->
<!--- six are likely indicators of a PR that is doing too many things. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that -->
<!--- apply. -->
- [x] I have run `rubocop` against the codebase
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
