### PR TITLE
Fix: Scope conflict for 'environment' variable

### DIFF
--- a/lib/seed_packet.rb
+++ b/lib/seed_packet.rb
@@ -8,11 +8,13 @@ module SeedPacket
   attr_accessor :environment,
                 :factory_class
 
+  # rubocop:disable Metrics/LineLength
   def initialize(environment: nil, factory_class: 'FactoryBot')
     self.environment = environment ? Environment.new(environment) : nil
 
-    self.factory_class = Object.const_get(factory_class) if environment.samples_allowed?
+    self.factory_class = Object.const_get(factory_class) if self.environment.samples_allowed?
   end
+  # rubocop:enable Metrics/LineLength
 
   def seed
     yield if environment.seeding_allowed?


### PR DESCRIPTION
<!--- Well formatted issues help everyone.  Take a few minutes to get a -->
<!--- primer on markdown here: http://bit.ly/2lB1raW -->

## Why This Change Is Necessary
The initializer for seed packet is not setting the factory_class instance variable. This is because the local `environment` variable from the keyword argument is being used when the check to set the factory_class occurs.
<!--- Identify the High Level Type of Change -->
- [x] Bug Fix
- [ ] New Feature

<!--- Now describe to reviewers of your pull request what to expect in the -->
<!--- PR, thereby allowing them to more easily identify and point out -->
<!--- unrelated changes. -->
This specifies the `self.environment` instance variable to be used when checking to set the factory_class 

## Side Effects Caused By This Change

- [ ] This Causes a Breaking Change

<!--- This is the most important topic to answer, as it can point out -->
<!--- problems where you are making too many changes in one commit or branch. -->
<!--- One or two bullet points for related changes may be okay, but five or -->
<!--- six are likely indicators of a PR that is doing too many things. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that -->
<!--- apply. -->
- [x] I have run `rubocop` against the codebase
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
